### PR TITLE
Log errors on the submission process

### DIFF
--- a/core/utils/request_submitter.py
+++ b/core/utils/request_submitter.py
@@ -240,6 +240,12 @@ class RequestSubmitter(BaseSubmitter):
                     refresh_workflows_in_stats([workflow_name])
 
             except Exception as ex:
+                self.logger.error(
+                    'Unable to submit request (%s): %s', 
+                    prepid, 
+                    ex, 
+                    exc_info=True
+                )
                 self.__handle_error(request, str(ex))
                 return
 


### PR DESCRIPTION
1. Log the error message with its stack trace

The issue was related to a configuration variable (`REMOTE_SSH_NODE`) in the runtime environment, pointing to a node that does not exist anymore. Nevertheless, use this opportunity to enhance the log to spot exceptions in the submission process.