### PR TITLE
Include the `job_dict_overwrite` feature for tickets

### DIFF
--- a/core/controller/ticket_controller.py
+++ b/core/controller/ticket_controller.py
@@ -167,6 +167,7 @@ class TicketController(ControllerBase):
         not_done = status != 'done'
         editing_info['input'] = not_done
         editing_info['__steps'] = not_done
+        editing_info['job_dict_overwrite'] = not_done
         for step_index, _ in enumerate(obj.get('steps')):
             editing_info['steps'].append({'subcampaign': step_index > 0 and not_done,
                                           'processing_string': step_index > 0 and not_done,
@@ -184,6 +185,7 @@ class TicketController(ControllerBase):
         ticket_prepid = ticket.get_prepid()
         created_requests = []
         request_controller = RequestController()
+        ticket_job_overwrite = ticket.get('job_dict_overwrite')
         with self.locker.get_lock(ticket_prepid):
             ticket = Ticket(json_input=database.get(ticket_prepid))
             created_requests = ticket.get('created_requests')
@@ -201,6 +203,7 @@ class TicketController(ControllerBase):
                     for step_index, step in enumerate(ticket.get('steps')):
                         subcampaign_name = step['subcampaign']
                         new_request_json = {'subcampaign': subcampaign_name,
+                                            'job_dict_overwrite': ticket_job_overwrite,
                                             'priority': step['priority'],
                                             'processing_string': step['processing_string'],
                                             'time_per_event': step['time_per_event'],

--- a/core/model/ticket.py
+++ b/core/model/ticket.py
@@ -28,6 +28,9 @@ class Ticket(ModelBase):
         'status': 'new',
         # List of dicts that have subcampaign, processing_string, size/time per event values
         'steps': [],
+        # Manual overwrite of job dictionary for the request to be created
+        # a default template for them
+        'job_dict_overwrite': {},
     }
 
     lambda_checks = {

--- a/scripts/add_job_dict_overwrite.py
+++ b/scripts/add_job_dict_overwrite.py
@@ -8,7 +8,7 @@ from core_lib.database.database import Database
 Database.set_credentials_file(os.getenv('DB_AUTH'))
 Database.set_database_name('rereco')
 
-database = Database('requests')
+database = Database('tickets')
 
 total_entries = database.get_count()
 

--- a/vue_frontend/src/components/TicketsEdit.vue
+++ b/vue_frontend/src/components/TicketsEdit.vue
@@ -9,6 +9,13 @@
           <td><input type="text" v-model="editableObject.prepid" :disabled="!editingInfo.prepid"></td>
         </tr>
         <tr>
+          <td>Job dict overwrite</td>
+          <td>
+            <span class="show-job-dict-overwrite" v-if="!showJobDictOverwrite" v-on:click="toggleJobDictOverwrite()">Edit</span>
+            <JSONField v-show="showJobDictOverwrite" v-model="editableObject.job_dict_overwrite" :disabled="!editingInfo.job_dict_overwrite"/>
+          </td>
+        </tr>
+        <tr>
           <td>Steps ({{listLength(editableObject.steps)}})</td>
           <td>
             <div v-for="(step, index) in editableObject.steps" :key="index">
@@ -155,12 +162,14 @@ import axios from 'axios'
 import { utilsMixin } from '../mixins/UtilsMixin.js'
 import LoadingOverlay from './LoadingOverlay.vue'
 import Autocompleter from './Autocompleter.vue'
+import JSONField from './JSONField.vue'
 
 export default {
   name: 'TicketsEdit',
   components: {
     LoadingOverlay,
-    Autocompleter
+    Autocompleter,
+    JSONField
   },
   mixins: [
     utilsMixin
@@ -170,6 +179,7 @@ export default {
       prepid: undefined,
       editableObject: {},
       editingInfo: {},
+      showJobDictOverwrite: false,
       loading: true,
       creatingNew: true,
       errorDialog: {
@@ -219,6 +229,7 @@ export default {
           templateInfo.input = templateInfo.input.filter(Boolean).join('\n');
           component.editableObject = templateInfo;
           component.editingInfo = editingInfo;
+          component.showJobDictOverwrite = Object.keys(component.editableObject.job_dict_overwrite) != 0;
           component.loading = false;
         }).catch(error => {
           component.loading = false;
@@ -232,6 +243,7 @@ export default {
         }
         component.editableObject = objectInfo;
         component.editingInfo = editingInfo;
+        component.showJobDictOverwrite = Object.keys(component.editableObject.job_dict_overwrite) != 0;
         if (component.creatingNew) {
           component.addStep();
         }
@@ -402,6 +414,27 @@ export default {
         window.location = 'subcampaigns?prepid=' + this.prepid;
       }
     },
+    toggleJobDictOverwrite: function() {
+      if (this.showJobDictOverwrite) {
+        this.showJobDictOverwrite = false;
+        return;
+      }
+      const component = this;
+      if (confirm('Are you sure you know what you are doing? This is a very dangerous action!')) {
+        component.showJobDictOverwrite = true;
+      }
+    },
   }
 }
 </script>
+
+<style>
+.show-job-dict-overwrite {
+  color: var(--v-anchor-base);
+  cursor: pointer;
+}
+.show-job-dict-overwrite:hover {
+  color: red;
+  font-weight: 700;
+}
+</style>


### PR DESCRIPTION
Completes: #130

Allow users to include tweaks for the job dictionary of new requests. The parameters included here will be appended as default for the new requests.